### PR TITLE
First step

### DIFF
--- a/Services/Sync.php
+++ b/Services/Sync.php
@@ -1,0 +1,48 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services;
+
+use Kwf\SyncBaseBundle\Services\Sync\LoggerInterface;
+use Kwf\SyncBaseBundle\Services\Sync\RetrieverInterface;
+use Kwf\SyncBaseBundle\Services\Sync\SyncModelInterface;
+use \Countable;
+
+class Sync
+{
+    /** @var RetrieverInterface $retriever */
+    protected $retriever;
+    /** @var SyncModelInterface[] $syncModels */
+    protected $syncModels;
+    /** @var LoggerInterface $logger */
+    protected $logger;
+
+    public function __construct(RetrieverInterface $retriever, array $syncModels, LoggerInterface $logger = null)
+    {
+        $this->retriever = $retriever;
+        $this->syncModels = $syncModels;
+        $this->logger = $logger;
+    }
+
+    public function sync()
+    {
+        if ($this->logger) $this->logger->startSync();
+        $iterator = $this->retriever->getIterator();
+        if ($iterator instanceof Countable || is_array($iterator)) {
+            if ($this->logger) $this->logger->setItemCount(count($iterator));
+        }
+        $index = 0;
+        foreach ($iterator as $item) {
+            if ($this->logger) $this->logger->processItem($item, $index);
+            foreach ($this->syncModels as $syncModel) {
+                if ($this->logger) $this->logger->processItem($item, $index, $syncModel);
+                $syncModel->updateOrCreate($item, $index);
+            }
+            $index++;
+        }
+        if ($this->logger) $this->logger->commitTransaction($index);
+        foreach ($this->syncModels as $syncModel) {
+            if ($this->logger) $this->logger->commitTransaction($index, $syncModel);
+            $syncModel->commitTransaction($index);
+        }
+        if ($this->logger) $this->logger->finishedSync();
+    }
+}

--- a/Services/Sync/LoggerInterface.php
+++ b/Services/Sync/LoggerInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync;
+
+interface LoggerInterface
+{
+    function startSync();
+    function setItemCount($count);
+    function processItem($rawData, $index, $syncModel = null);
+    function commitTransaction($countItems, $syncModel = null);
+    function finishedSync();
+}

--- a/Services/Sync/NormalizerInterface.php
+++ b/Services/Sync/NormalizerInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync;
+
+interface NormalizerInterface
+{
+    /**
+     * @param $rawData
+     * @return array
+     */
+    function normalize($rawData);
+}

--- a/Services/Sync/RetrieverInterface.php
+++ b/Services/Sync/RetrieverInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync;
+
+use \IteratorAggregate;
+
+interface RetrieverInterface extends IteratorAggregate
+{
+}

--- a/Services/Sync/SyncModel/BasicLoggerInterface.php
+++ b/Services/Sync/SyncModel/BasicLoggerInterface.php
@@ -1,0 +1,14 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel;
+
+interface BasicLoggerInterface
+{
+    function callUpdateOrCreateForData($rawData);
+    function rawDataNormalized($rawData, $normalizedData);
+    function itemRestored($item, $normalizedData, $syncModel);
+    function itemCreated($item, $normalizedData, $syncModel);
+    function itemUpdated($item, $normalizedData, $syncModel);
+    function callUpdateOrCreateOnAdditionalSyncModel($rawData, $syncModel, $additionalSyncModel = null);
+    function callCommitTransactionOnAdditionalSyncModel($countItems, $syncModel, $additionalSyncModel = null);
+    function summary();
+}

--- a/Services/Sync/SyncModel/BasicModelInterface.php
+++ b/Services/Sync/SyncModel/BasicModelInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel;
+
+interface BasicModelInterface
+{
+    function getItem($normalizedData);
+    function restoreItem($normalizedData);
+    function createItem($normalizedData);
+    function updateItem($item, $normalizedData);
+    function getId($item);
+}

--- a/Services/Sync/SyncModel/BasicSyncModel.php
+++ b/Services/Sync/SyncModel/BasicSyncModel.php
@@ -1,0 +1,58 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel;
+
+use Kwf\SyncBaseBundle\Services\Sync\NormalizerInterface;
+use Kwf\SyncBaseBundle\Services\Sync\SyncModelInterface;
+
+abstract class BasicSyncModel implements SyncModelInterface
+{
+    protected $normalizer;
+    protected $model;
+    /** @var SyncModelInterface[] $additionalSyncModels */
+    protected $additionalSyncModels;
+    protected $logger;
+    protected $seenItemIds = array();
+    public function __construct(NormalizerInterface $normalizer, BasicModelInterface $model, $additionalSyncModels = array(), BasicLoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer;
+        $this->model = $model;
+        $this->additionalSyncModels = $additionalSyncModels;
+        $this->logger = $logger;
+    }
+
+    function updateOrCreate($rawData, $index, $parentItem = null)
+    {
+        if ($this->logger) $this->logger->callUpdateOrCreateForData($rawData);
+        $normalizedData = $this->normalizer->normalize($rawData);
+        if ($this->logger) $this->logger->rawDataNormalized($rawData, $normalizedData);
+        $item = $this->model->getItem($normalizedData);
+        if (!$item) {
+            $item = $this->model->restoreItem($normalizedData);
+            if ($item && $this->logger) $this->logger->itemRestored($item, $normalizedData, $this->model);
+            if (!$item) {
+                $this->model->createItem($normalizedData);
+                if ($this->logger) $this->logger->itemCreated($item, $normalizedData, $this->model);
+            }
+        } else {
+            $this->model->updateItem($item, $normalizedData);
+            if ($this->logger) $this->logger->itemUpdated($item, $normalizedData, $this->model);
+        }
+
+        if ($this->logger) $this->logger->callUpdateOrCreateOnAdditionalSyncModel($rawData, $this->model);
+        foreach ($this->additionalSyncModels as $additionalSyncModel) {
+            if ($this->logger) $this->logger->callUpdateOrCreateOnAdditionalSyncModel($rawData, $this->model, $additionalSyncModel);
+            $additionalSyncModel->updateOrCreate($rawData, $index, $item);
+        }
+
+        $this->seenItemIds[] = $this->model->getId($item);
+    }
+
+    function commitTransaction($countItems)
+    {
+        if ($this->logger) $this->logger->callCommitTransactionOnAdditionalSyncModel($countItems, $this->model);
+        foreach ($this->additionalSyncModels as $additionalSyncModel) {
+            if ($this->logger) $this->logger->callCommitTransactionOnAdditionalSyncModel($countItems, $this->model, $additionalSyncModel);
+            $additionalSyncModel->commitTransaction($countItems);
+        }
+    }
+}

--- a/Services/Sync/SyncModel/DeleteAllTogether.php
+++ b/Services/Sync/SyncModel/DeleteAllTogether.php
@@ -1,0 +1,26 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel;
+
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeleteAllTogether\LoggerInterface;
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeleteAllTogether\ModelInterface;
+use Kwf\SyncBaseBundle\Services\Sync\NormalizerInterface;
+
+class DeleteAllTogether extends BasicSyncModel
+{
+    /** @var ModelInterface $model */
+    protected $model;
+    /** @var LoggerInterface $logger */
+    protected $logger;
+    public function __construct(NormalizerInterface $normalizer, ModelInterface $model, $additionalSyncModels = array(), LoggerInterface $logger = null)
+    {
+        parent::__construct($normalizer, $model, $additionalSyncModels, $logger);
+    }
+
+    function commitTransaction($countItems)
+    {
+        parent::commitTransaction($countItems);
+        if ($this->logger) $this->logger->seenItemIds($this->seenItemIds);
+        $this->model->deleteOthers($this->seenItemIds);
+        if ($this->logger) $this->logger->summary();
+    }
+}

--- a/Services/Sync/SyncModel/DeleteAllTogether/LoggerInterface.php
+++ b/Services/Sync/SyncModel/DeleteAllTogether/LoggerInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeleteAllTogether;
+
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\BasicLoggerInterface;
+
+interface LoggerInterface extends BasicLoggerInterface
+{
+    function seenItemIds($itemIds);
+}

--- a/Services/Sync/SyncModel/DeleteAllTogether/ModelInterface.php
+++ b/Services/Sync/SyncModel/DeleteAllTogether/ModelInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeleteAllTogether;
+
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\BasicModelInterface;
+
+interface ModelInterface extends BasicModelInterface
+{
+    function deleteOthers($itemIds);
+}

--- a/Services/Sync/SyncModel/DeletePerItem.php
+++ b/Services/Sync/SyncModel/DeletePerItem.php
@@ -1,0 +1,28 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel;
+
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeletePerItem\LoggerInterface;
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeletePerItem\ModelInterface;
+use Kwf\SyncBaseBundle\Services\Sync\NormalizerInterface;
+
+class DeletePerItem extends BasicSyncModel
+{
+    /** @var ModelInterface $model */
+    protected $model;
+    /** @var LoggerInterface $model */
+    protected $logger;
+    public function __construct(NormalizerInterface $normalizer, ModelInterface $model, $additionalSyncModels = array(), LoggerInterface $logger = null)
+    {
+        parent::__construct($normalizer, $model, $additionalSyncModels, $logger);
+    }
+
+    function commitTransaction($countItems)
+    {
+        parent::commitTransaction($countItems);
+        foreach (array_diff($this->model->getAllIds(), $this->seenItemIds) as $idToDelete) {
+            if ($this->logger) $this->logger->itemIdToDelete($idToDelete);
+            $this->model->deleteItem($idToDelete);
+        }
+        if ($this->logger) $this->logger->summary();
+    }
+}

--- a/Services/Sync/SyncModel/DeletePerItem/LoggerInterface.php
+++ b/Services/Sync/SyncModel/DeletePerItem/LoggerInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeletePerItem;
+
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\BasicLoggerInterface;
+
+interface LoggerInterface extends BasicLoggerInterface
+{
+    function itemIdToDelete($itemId);
+}

--- a/Services/Sync/SyncModel/DeletePerItem/ModelInterface.php
+++ b/Services/Sync/SyncModel/DeletePerItem/ModelInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync\SyncModel\DeletePerItem;
+
+use Kwf\SyncBaseBundle\Services\Sync\SyncModel\BasicModelInterface;
+
+interface ModelInterface extends BasicModelInterface
+{
+    function deleteItem($id);
+    function getAllIds();
+}

--- a/Services/Sync/SyncModelInterface.php
+++ b/Services/Sync/SyncModelInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace Kwf\SyncBaseBundle\Services\Sync;
+
+interface SyncModelInterface
+{
+    function updateOrCreate($rawData, $index, $parentItem = null);
+    function commitTransaction($countItems);
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "koala-framework/sync-base",
+    "description": "",
+    "homepage": "https://github.com/koala-framework/sync-base",
+    "license": "BSD-2-Clause",
+    "require": {
+    },
+    "autoload": {
+        "psr-4": { "Kwf\\SyncBaseBundle\\": "" }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require-dev": {
+        "symfony/phpunit-bridge": "^5.1"
+    }
+}


### PR DESCRIPTION
Sync does process only on one source, but can be stored via multiple
syncModels. How raw-data is normalized depends on how the data has to be
stored therefore normalizing is part of a syncModel.
Sync.php does not directly contain specific functions like getItem,
restoreItem and so on to support syncing Helpers like
Kwf_Util_ModelSync.