### PR TITLE
Prevent setting value, if mapping has more than one entry

### DIFF
--- a/Services/Sync/Normalizer/ConfigurableNormalizer.php
+++ b/Services/Sync/Normalizer/ConfigurableNormalizer.php
@@ -78,7 +78,7 @@ class ConfigurableNormalizer implements NormalizerInterface
                 if (!isset($drilledCarData[$mapKey])) {
                     continue;
                 }
-                if (!is_array($drilledCarData[$mapKey]) || $index + 1 === count($map)) {
+                if (!is_array($drilledCarData[$mapKey]) || (count($mapping) === 1 && $index + 1 === count($map))) {
                     $value = $drilledCarData[$mapKey];
                     break;
                 }


### PR DESCRIPTION
Multiple entries in a mapping mean, that if the first entry was not found,
the next entry should be used to determine the value of a field.
For that reason we cannot set the value of the field just yet and we need to keep
through the data until a value was found or the value remains empty.