### PR TITLE
Return full raw data if the attribute name is null

### DIFF
--- a/Services/Sync/SyncModel/ChildEntriesAdapter.php
+++ b/Services/Sync/SyncModel/ChildEntriesAdapter.php
@@ -23,7 +23,7 @@ class ChildEntriesAdapter implements SyncModelInterface
     {
         $usedPartOfRawData = $rawData;
         foreach (explode(".", $this->attributeName) as $attributeName) {
-            $usedPartOfRawData = $usedPartOfRawData[$attributeName];
+            $usedPartOfRawData = is_null($attributeName) ? $usedPartOfRawData : $usedPartOfRawData[$attributeName];
         }
 
         $index = 0;


### PR DESCRIPTION
Manchmal wollen wir die gesamten Rohdaten verarbeiten, und nicht nur einen durch das Attribut bestimmten Teil der Daten. Wenn also null anstelle eines Attributs übergeben wird, bekommen wir nun den gesamten Datensatz.