### PR TITLE
Use deleted flag of normalized data if it exists

### DIFF
--- a/Services/Sync/SyncModel/BasicModelKwfWrapper.php
+++ b/Services/Sync/SyncModel/BasicModelKwfWrapper.php
@@ -71,7 +71,7 @@ abstract class BasicModelKwfWrapper implements BasicModelInterface
         $row = $this->model->getRow($select);
         if (!$row) return null;
 
-        $row->deleted = false;
+        $row->deleted = array_key_exists('deleted', $normalizedData) ? $normalizedData['deleted'] : false;
         $row->save();
         return $row;
     }


### PR DESCRIPTION
Ich hatte hier das Problem, dass Elemente wiederhergestellt wurden, obwohl ich in den normalisierten Daten deleted = true geschickt hatte.