### PR TITLE
Do not add skipped-parent-item in child model

### DIFF
--- a/Services/Sync/SyncModel/ProcessChanged.php
+++ b/Services/Sync/SyncModel/ProcessChanged.php
@@ -50,7 +50,6 @@ class ProcessChanged extends BasicSyncModel
                 if ($this->logger) $this->logger->itemUpdated($item, $normalizedData, $this->model);
             } else {
                 if ($this->logger) $this->logger->itemSkipped($normalizedData, $this->model);
-                if ($parentItem) $this->addSkippedParentItemId($this->model->getParentId($item));
             }
             $this->seenItemIds[] = $this->model->getId($item, $parentItem);
         }


### PR DESCRIPTION
Child models do not have a last-update-field and have added a skipped-parent-item every time
they were processed. This has led to the fact that child relations were not deleted correctly.
If a parent is skipped because it has not changed, the parent itself will add its own skipped id
to the child model and don't even process any relations in these child models.