### PR TITLE
Always update items without lastUpdateFieldName

### DIFF
--- a/Services/Sync/SyncModel/ProcessChanged/BasicModelKwfWrapper.php
+++ b/Services/Sync/SyncModel/ProcessChanged/BasicModelKwfWrapper.php
@@ -43,7 +43,9 @@ class BasicModelKwfWrapper extends \Kwf\SyncBaseBundle\Services\Sync\SyncModel\B
 
     function needsUpdate($item, $normalizedData)
     {
-        return $this->lastUpdateFieldName && strtotime($item->{$this->lastUpdateFieldName}) < strtotime($normalizedData[$this->lastUpdateFieldName]);
+        return $this->lastUpdateFieldName
+            ? strtotime($item->{$this->lastUpdateFieldName}) < strtotime($normalizedData[$this->lastUpdateFieldName])
+            : true; // always update items without lastUpdateFieldName
     }
 
 }


### PR DESCRIPTION
Das ist wichtig, wenn Hauptdatensätze (z.B. Betriebe) über andere Datensätze (z.B. Personen) komplett und nicht inkrementell gesynct werden sollen.